### PR TITLE
feat: Mark enhancement — AI analysis, share, export (#12)

### DIFF
--- a/migrations/014_mark_enhancement.sql
+++ b/migrations/014_mark_enhancement.sql
@@ -1,0 +1,12 @@
+-- Migration 014: Mark Enhancement (#12)
+-- Adds AI analysis, share tokens, and digest_id to marks
+
+ALTER TABLE marks ADD COLUMN analysis TEXT DEFAULT NULL;
+ALTER TABLE marks ADD COLUMN analyzed_at TEXT DEFAULT NULL;
+ALTER TABLE marks ADD COLUMN share_token TEXT DEFAULT NULL;
+ALTER TABLE marks ADD COLUMN digest_id INTEGER DEFAULT NULL REFERENCES digests(id);
+ALTER TABLE marks ADD COLUMN tags TEXT DEFAULT '[]';
+
+CREATE UNIQUE INDEX idx_marks_share_token ON marks(share_token) WHERE share_token IS NOT NULL;
+CREATE INDEX idx_marks_user_analyzed ON marks(user_id, analyzed_at);
+CREATE INDEX idx_marks_digest ON marks(digest_id) WHERE digest_id IS NOT NULL;

--- a/src/db.mjs
+++ b/src/db.mjs
@@ -268,13 +268,14 @@ export function revokeMarkShare(db, id, userId) {
   return db.prepare('UPDATE marks SET share_token = NULL WHERE id = ? AND user_id = ?').run(id, userId);
 }
 
-export function listMarksForExport(db, userId, { status, since, until } = {}) {
+export function listMarksForExport(db, userId, { status, since, until, limit = 1000 } = {}) {
   let sql = 'SELECT * FROM marks WHERE user_id = ?';
   const params = [userId];
   if (status) { sql += ' AND status = ?'; params.push(status); }
   if (since) { sql += ' AND created_at >= ?'; params.push(since); }
   if (until) { sql += ' AND created_at <= ?'; params.push(until); }
-  sql += ' ORDER BY created_at DESC';
+  sql += ' ORDER BY created_at DESC LIMIT ?';
+  params.push(limit);
   return db.prepare(sql).all(...params);
 }
 

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -44,8 +44,9 @@ const LLM_TIMEOUT = parseInt(process.env.LLM_TIMEOUT || env.LLM_TIMEOUT || '90',
 mkdirSync(join(ROOT, 'data'), { recursive: true });
 const db = getDb(DB_PATH);
 
-// Chat rate limiting (in-memory, per user)
+// Rate limiting (in-memory, per user)
 const chatRateLimit = new Map();
+const analyzeRateLimit = new Map();
 
 // ── Shared LLM helper ──
 function callLlmApi(messages, { maxTokens = 1024, temperature = 0.3 } = {}) {
@@ -663,15 +664,26 @@ const server = createServer(async (req, res) => {
     }
 
     // POST /api/marks/:id/analyze — trigger AI analysis for a mark
+    // Rate limit: 5 requests per minute per user (M-1: prevent LLM quota abuse)
     const markAnalyzeMatch = path.match(/^\/api\/marks\/(\d+)\/analyze$/);
     if (req.method === 'POST' && markAnalyzeMatch) {
       if (!req.user) return json(res, { error: 'not authenticated' }, 401);
       if (!LLM_API_KEY) return json(res, { error: 'analysis not configured' }, 503);
+      const now = Date.now();
+      const uid = req.user.id;
+      if (!analyzeRateLimit.has(uid)) analyzeRateLimit.set(uid, []);
+      const ts = analyzeRateLimit.get(uid).filter(t => now - t < 60000);
+      if (ts.length >= 5) return json(res, { error: 'rate limit exceeded, try again later' }, 429);
+      ts.push(now);
+      analyzeRateLimit.set(uid, ts);
       const markId = parseInt(markAnalyzeMatch[1]);
       const mark = getMark(db, markId, req.user.id);
       if (!mark) return json(res, { error: 'mark not found' }, 404);
 
       try {
+        // User-supplied title/note/URL are interpolated into the prompt. Prompt injection
+        // risk is low: analysis is stored in the user's own mark and only shared if the
+        // user explicitly creates a share link (user-initiated action).
         const analysisPrompt = `Analyze this bookmarked article and provide a structured analysis.
 
 Title: ${(mark.title || '').slice(0, 200)}
@@ -725,11 +737,10 @@ Format the analysis in clear markdown. Return the topic tags as a JSON array on 
       return json(res, { share_token: token, url: `/api/marks/shared/${token}` });
     }
 
-    // DELETE /api/marks/:id/share — revoke share link
-    const markUnshareMatch = path.match(/^\/api\/marks\/(\d+)\/share$/);
-    if (req.method === 'DELETE' && markUnshareMatch) {
+    // DELETE /api/marks/:id/share — revoke share link (L-1: reuse markShareMatch)
+    if (req.method === 'DELETE' && markShareMatch) {
       if (!req.user) return json(res, { error: 'not authenticated' }, 401);
-      const markId = parseInt(markUnshareMatch[1]);
+      const markId = parseInt(markShareMatch[1]);
       revokeMarkShare(db, markId, req.user.id);
       return json(res, { ok: true });
     }


### PR DESCRIPTION
## Summary

Implements issue #12 — Mark (bookmark) enhancement with AI-powered features.

**New capabilities:**
- **AI Analysis**: `POST /api/marks/:id/analyze` — LLM generates structured analysis (summary, key topics, significance, related areas) + extracts topic tags
- **Share Links**: `POST /api/marks/:id/share` creates a public share token; `DELETE` revokes it. Public endpoint (`GET /api/marks/shared/:token`) returns safe fields only (no user_id or internal IDs)
- **Export**: `GET /api/marks/export` — Markdown (default) or JSON format with optional date range and status filters
- **Digest Preference Tuning**: Generator injects bookmark topic tags into the LLM prompt so digests prioritize content matching user interests

**Changes:**
- Migration 014: adds `analysis`, `analyzed_at`, `share_token`, `digest_id`, `tags` columns to marks table
- `src/db.mjs`: 8 new DB functions (getMark, updateMarkAnalysis, setMarkShareToken, getMarkByShareToken, revokeMarkShare, listMarksForExport, getUserMarkTopics)
- `src/server.mjs`: 6 new API endpoints + shared `callLlmApi` helper
- `src/generator.mjs`: bookmark topic injection into digest generation prompt
- `test/e2e.sh`: 15 new tests (all passing)

## Test plan
- [x] All 15 new tests pass (section 19)
- [x] All existing tests still pass (102/109, 7 pre-existing failures in sections 14+17 due to missing API_KEY/LLM config)
- [ ] Boot security review
- [ ] Test with live LLM (analyze endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)