### PR TITLE
ci: add SAST (Semgrep + Gitleaks)

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -1,0 +1,33 @@
+name: SAST
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: Semgrep Code Scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Semgrep
+        run: semgrep scan --config auto --error --severity ERROR
+
+  gitleaks:
+    name: Gitleaks Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Gitleaks
+        run: |
+          GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | cut -d'"' -f4 | sed 's/^v//')
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz -C /usr/local/bin gitleaks
+      - name: Run Gitleaks
+        run: gitleaks detect --source . --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+# Gitleaks configuration
+# Pre-existing findings in historical commits are allowlisted below.
+# New secrets introduced after this PR will still be caught.
+
+[allowlist]
+description = "Pre-existing findings in historical commits"
+commits = [
+  # docs/STAGING.md line 42: placeholder staging API key in curl example (not a real credential)
+  "554b84bd20514c0dd4ff76092e2fa44e7c000226",
+]


### PR DESCRIPTION
## Summary
- Add Semgrep SAST scanning for security vulnerabilities
- Add Gitleaks secret detection to prevent credential leaks
- CI already exists (lint + e2e + security audit)
- SOC 2 compliance requirement (SA-1-6)

## Notes
One pre-existing finding was detected during local Gitleaks scan: a placeholder staging API key (`staging-api-key-1234`) in `docs/STAGING.md` line 42, committed Feb 2026. This is a non-real credential used in a curl example. The commit is allowlisted in `.gitleaks.toml` so the CI scan passes; all new secrets introduced after this PR will still be caught.

## Test plan
- [ ] Semgrep scan passes on this PR
- [ ] Gitleaks scan passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)