### PR TITLE
fix(ci): shell injection + chat auth order

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,9 +24,11 @@ jobs:
 
       - name: Determine Docker Tags
         id: docker_tags
+        env:
+          GIT_REF: ${{ github.ref }}
         run: |
           TAGS=""
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+          if [[ "$GIT_REF" == refs/tags/v* ]]; then
             TAG_VERSION=${GITHUB_REF#refs/tags/}
             TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG_VERSION},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
             echo "Building release: $TAG_VERSION"

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -1208,8 +1208,13 @@ Format the analysis in clear markdown. Return the topic tags as a JSON array on 
 
     // ── Chat endpoint ──
     if (req.method === 'POST' && path === '/api/chat') {
-      if (!LLM_API_KEY) return json(res, { error: 'chat not configured' }, 503);
       if (!req.user) return json(res, { error: 'login required' }, 401);
+
+      const body = await parseBody(req);
+      const { message, history, digest_id } = body;
+      if (!message || typeof message !== 'string') return json(res, { error: 'message required' }, 400);
+
+      if (!LLM_API_KEY) return json(res, { error: 'chat not configured' }, 503);
 
       // Rate limit: max 20 requests per minute per user
       const now = Date.now();
@@ -1219,10 +1224,6 @@ Format the analysis in clear markdown. Return the topic tags as a JSON array on 
       if (timestamps.length >= 20) return json(res, { error: 'rate limit exceeded, try again later' }, 429);
       timestamps.push(now);
       chatRateLimit.set(userId, timestamps);
-
-      const body = await parseBody(req);
-      const { message, history, digest_id } = body;
-      if (!message || typeof message !== 'string') return json(res, { error: 'message required' }, 400);
 
       // Get digest content for context
       let digestContent = '';


### PR DESCRIPTION
## Summary
Two pre-existing issues uncovered by Owen's SAST PR #22:

1. **Shell injection** (`docker-build.yml`): `${{ github.ref }}` used directly in `run:` step. Fixed by using `env:` intermediate variable. (Semgrep `run-shell-injection`)

2. **Chat auth order** (`server.mjs`): `/api/chat` checked LLM config before auth, causing "chat not configured" to leak to unauthenticated users and breaking e2e tests 17.1 + 17.2 in CI (where `LLM_API_KEY` is unset). Fixed by checking auth first.

## Test plan
- [ ] Semgrep scan passes (no more `run-shell-injection`)
- [ ] e2e tests 17.1 + 17.2 pass (auth checked before config)
- [ ] Docker build still works

Once merged, Owen's #22 can rebase and all CI will be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)